### PR TITLE
Fix conflicting WebServlet annotation causing 503 error

### DIFF
--- a/src/main/java/com/google/codeu/servlets/StatsUserCountServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsUserCountServlet.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Handles fetching site statistics.
  */
-@WebServlet("/stats/user")
+@WebServlet("/stats/usercount")
 public class StatsUserCountServlet extends HttpServlet {
 
 	private Datastore datastore;


### PR DESCRIPTION
Loading the webapp causes a 503 error due to conflicting WebServlet annotations between the StatsUserCountServlet and the StatsUserServlet.