### PR TITLE
 Added quill rich text-editor and removed BBCode support library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@ limitations under the License.
       <artifactId>google-cloud-datastore</artifactId>
       <version>1.52.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.kefirsf</groupId>
-      <artifactId>kefirbb</artifactId>
-      <version>1.5</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/codeu/servlets/AboutMeServlet.java
+++ b/src/main/java/com/google/codeu/servlets/AboutMeServlet.java
@@ -15,8 +15,6 @@ import com.google.codeu.data.User;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
-import org.kefirsf.bb.BBProcessorFactory;
-import org.kefirsf.bb.TextProcessor;
 
 /**
  * Handles fetching and saving user data.
@@ -67,11 +65,8 @@ public class AboutMeServlet extends HttpServlet {
     String userEmail = userService.getCurrentUser().getEmail();
     String userEnteredContent = request.getParameter("about-me");
 
-    TextProcessor processor = BBProcessorFactory.getInstance().create();
-    String htmlConvertedContent = processor.process(userEnteredContent);
-
-    Whitelist whitelist = Whitelist.basicWithImages();
-    String sanitizedContent = Jsoup.clean(htmlConvertedContent, whitelist);
+    Whitelist whitelist = Whitelist.none();
+    String sanitizedContent = Jsoup.clean(userEnteredContent, whitelist);
 
     User user = new User(userEmail, sanitizedContent);
     datastore.storeUser(user);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -34,8 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
-import org.kefirsf.bb.BBProcessorFactory;
-import org.kefirsf.bb.TextProcessor;
+
 
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
@@ -107,11 +106,8 @@ public class MessageServlet extends HttpServlet {
     String user = userService.getCurrentUser().getEmail();
     String userEnteredContent = request.getParameter("text");
 
-    TextProcessor processor = BBProcessorFactory.getInstance().create();
-    String htmlConvertedContent = processor.process(userEnteredContent);
-
-    Whitelist whitelist = Whitelist.basicWithImages();
-    String sanitizedContent = Jsoup.clean(htmlConvertedContent, whitelist);
+    Whitelist whitelist = Whitelist.relaxed();
+    String sanitizedContent = Jsoup.clean(userEnteredContent, whitelist);
 
     String textWithMedia = insertMediaTag(sanitizedContent);
 

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -15,15 +15,10 @@
  */
 
 #editor-container {
-  -moz-appearance: textfield-multiline;
-  -webkit-appearance: textarea;
   background-color: white;
-  background-color: -moz-field;
-  border: 1px solid gray;
-  overflow: auto;
-  padding: 2px;
-  resize: both;
   height: 100px;
+  overflow: auto;
+  resize: both;
 }
 
 /* Give each message a rounded border. */

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -23,14 +23,7 @@
   overflow: auto;
   padding: 2px;
   resize: both;
-  height: 130px;
-}
-
-/* Set the size of the message input to be 100 pixels high
-   and will fill the width of its parent element. */
-#message-input {
   height: 100px;
-  width: 100%;
 }
 
 /* Give each message a rounded border. */

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+#editor-container {
+  -moz-appearance: textfield-multiline;
+  -webkit-appearance: textarea;
+  background-color: white;
+  background-color: -moz-field;
+  border: 1px solid gray;
+  overflow: auto;
+  padding: 2px;
+  resize: both;
+  height: 130px;
+}
+
 /* Set the size of the message input to be 100 pixels high
    and will fill the width of its parent element. */
 #message-input {
@@ -50,7 +62,7 @@
 
 .message-body video {
   display: block;
-  margin-top: 25px; 
+  margin-top: 25px;
   margin-left: auto;
   margin-right: auto;
   max-width: 75%;
@@ -58,14 +70,14 @@
 
 .message-body audio {
   display: block;
-  margin-top: 25px; 
+  margin-top: 25px;
   margin-left: auto;
   margin-right: auto;
   max-width: 75%;
 }
 
 .message-body figure {
-  display: table; 
+  display: table;
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/main/webapp/js/quill-editor.js
+++ b/src/main/webapp/js/quill-editor.js
@@ -6,6 +6,7 @@ var quill = new Quill('#editor-container', {
       [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
     ]
   },
+  bounds: document.querySelector('#editor-container'),
   placeholder: 'Compose a message...',
   theme: 'snow'
 });

--- a/src/main/webapp/js/quill-editor.js
+++ b/src/main/webapp/js/quill-editor.js
@@ -1,0 +1,18 @@
+var quill = new Quill('#editor-container', {
+  modules: {
+    toolbar: [
+      ['bold', 'italic','underline','link'],
+      [{ list: 'ordered' }, { list: 'bullet' }],
+      [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+    ]
+  },
+  placeholder: 'Compose a message...',
+  theme: 'snow'
+});
+var form = document.querySelector('form');
+function copyInput() {
+  // Populate hidden form on submit
+  var message = document.querySelector('textarea[name=text]');
+  message.value = quill.root.innerHTML;
+  return true;
+};

--- a/src/main/webapp/js/quill-editor.js
+++ b/src/main/webapp/js/quill-editor.js
@@ -1,19 +1,18 @@
-var quill = new Quill('#editor-container', {
+const quill = new Quill('#editor-container', {
   modules: {
     toolbar: [
-      ['bold', 'italic','underline','link'],
+      ['bold', 'italic', 'underline', 'link'],
       [{ list: 'ordered' }, { list: 'bullet' }],
-      [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+      [{ header: [1, 2, 3, 4, 5, 6, false] }],
     ]
   },
   bounds: document.querySelector('#editor-container'),
   placeholder: 'Compose a message...',
   theme: 'snow'
 });
-var form = document.querySelector('form');
 function copyInput() {
   // Populate hidden form on submit
-  var message = document.querySelector('textarea[name=text]');
+  const message = document.querySelector('textarea[name=text]');
   message.value = quill.root.innerHTML;
   return true;
-};
+}

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -54,7 +54,7 @@ limitations under the License.
         </form>
       </div>
 
-      <form id="message-form" action="/messages" onsubmit="return copyInput()" method="POST" class="hidden">
+      <form id="message-form" action="/messages" onsubmit="return copyInput();" method="POST" class="hidden">
         <textarea name="text" id="message-input" class="hidden"></textarea>
         <br />
         Enter a new message:

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -23,6 +23,7 @@ limitations under the License.
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/nav-bar.css">
   <link rel="stylesheet" href="/css/user-page.css">
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
@@ -53,10 +54,14 @@ limitations under the License.
         </form>
       </div>
 
-      <form id="message-form" action="/messages" method="POST" class="hidden">
+      <form id="message-form" action="/messages" onsubmit="return copyInput()" method="POST" class="hidden">
+        <textarea name="text" id="message-input" class="hidden"></textarea>
+        <br />
         Enter a new message:
         <br />
-        <textarea name="text" id="message-input"></textarea>
+        <div id="editor-container">
+
+        </div>
         <br />
         <input type="submit" value="Submit">
       </form>
@@ -66,6 +71,8 @@ limitations under the License.
     </div>
 </body>
 <footer>
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+  <script src="./js/quill-editor.js"></script>
   <script src="./js/navigation-loader.js"></script>
   <script src="/js/user-page-loader.js"></script>
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"


### PR DESCRIPTION
I add a rich text-editor ([Quill](https://quilljs.com/)) to support user's message input. So, users don't need to know about BBCode format. As a result, StyledText part 1's BBCode converter library is no longer needed, so I deleted it.
![Annotation 2019-06-14 210713](https://user-images.githubusercontent.com/25432388/59517737-3689c200-8eea-11e9-909b-9cf7ecc9b378.jpg)

2. As for about-me input, I think it is better to be simple. So, I don't add editor and change `Whitelist.basicWithImages()` to `Whitelist.none()`. 
