### PR TITLE
fix a bug of showing html tags in public feed

### DIFF
--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -5,6 +5,7 @@
   <title>Message Feed</title>
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/nav-bar.css">
+  <link rel="stylesheet" href="/css/user-page.css">
   <meta charset="UTF-8">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">

--- a/src/main/webapp/js/feed.js
+++ b/src/main/webapp/js/feed.js
@@ -14,7 +14,7 @@ function buildMessageDiv(message) {
 
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('message-body');
-  bodyDiv.appendChild(document.createTextNode(message.text));
+  bodyDiv.innerHTML = message.text;
 
   const messageDiv = document.createElement('div');
   messageDiv.classList.add('message-div');


### PR DESCRIPTION
A small fix in feed.js. Html tags are showing instead of how it supposed to be.

Changes from this one 
![Annotation 2019-06-15 145858](https://user-images.githubusercontent.com/25432388/59549379-a481c800-8f82-11e9-9cee-690f96938c7e.jpg)

to this one.
![Annotation 2019-06-15 152440](https://user-images.githubusercontent.com/25432388/59549388-c8450e00-8f82-11e9-9b72-c36357ed8d3f.jpg)

