### PR TITLE
fix a small problem about nav showing below the contents

### DIFF
--- a/src/main/webapp/css/nav-bar.css
+++ b/src/main/webapp/css/nav-bar.css
@@ -14,6 +14,7 @@ section.sec1 {
 
 nav {
   position: fixed;
+  z-index: 2;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Problem is like this.
In `YOUR PAGE`
![Annotation 2019-06-16 192300](https://user-images.githubusercontent.com/25432388/59565049-3a495000-9074-11e9-8087-ab6491e3fd94.jpg)

In `OUR TEAM`
![Annotation 2019-06-16 202131](https://user-images.githubusercontent.com/25432388/59565061-5a790f00-9074-11e9-9970-bc624e0f8eb8.jpg)
