### PR TITLE
follow fix

### DIFF
--- a/src/main/webapp/js/build-message.js
+++ b/src/main/webapp/js/build-message.js
@@ -108,7 +108,7 @@ function follow(user, currentUser) {
       console.log(res);
     });
   const bottons = document.getElementsByName(user);
-  bottons.forEach(function(button) {
+  bottons.forEach((button) => {
     button.setAttribute('class', 'btn btn-secondary');
     button.innerText = 'Unfollow';
   });
@@ -123,7 +123,7 @@ function unFollow(user, currentUser) {
       console.log(res);
     });
   const bottons = document.getElementsByName(user);
-  bottons.forEach(function(button) {
+  bottons.forEach((button) => {
     button.setAttribute('class', 'btn btn-primary');
     button.innerText = 'Follow';
   });

--- a/src/main/webapp/js/build-message.js
+++ b/src/main/webapp/js/build-message.js
@@ -107,16 +107,26 @@ function follow(user, currentUser) {
     .then((res) => {
       console.log(res);
     });
+  const bottons = document.getElementsByName(user);
+  bottons.forEach(function(button) {
+    button.setAttribute('class', 'btn btn-secondary');
+    button.innerText = 'Unfollow';
+  });
 }
 
 function unFollow(user, currentUser) {
   console.log(user);
   console.log(currentUser);
-  fetch(`follow?followeremail=${currentUser}&followingemail=${user}`, httpOptions('DELETE')) // 
+  fetch(`follow?followeremail=${currentUser}&followingemail=${user}`, httpOptions('DELETE')) //
     .then(response => response.json())
     .then((res) => {
       console.log(res);
     });
+  const bottons = document.getElementsByName(user);
+  bottons.forEach(function(button) {
+    button.setAttribute('class', 'btn btn-primary');
+    button.innerText = 'Follow';
+  });
 }
 
 function toggleFollow(user, currentUser, messageIndex) {
@@ -199,6 +209,7 @@ function buildMessageDiv(message, messageIndex, profilePromise) {
       const followButton = document.createElement('button');
       const followButtonId = `follow-button-${messageIndex.toString()}`;
       followButton.setAttribute('id', followButtonId);
+      followButton.setAttribute('name', message.user);
 
       const url = "/followers?user=" + message.user;
       const followButtonStylePromise = fetch(url).then(res2 => { return res2.json() });

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -124,12 +124,15 @@ function fetchFollowers() {
     .then(response => response.json())
     .then((responses) => {
       const followersElement = document.getElementById("followers-details-modal-body");
+      while (followersElement.firstChild) {
+        followersElement.removeChild(followersElement.firstChild);
+      }
+      const followersNumberElement = document.getElementById("followers-num");
       if (responses === null) {
         followersElement.appendChild(document.createTextNode("You don't have any followers yet."));
+        followersNumberElement.innerText = '0';
       } else {
-        while (followersElement.firstChild) {
-          followersElement.removeChild(followersElement.firstChild);
-        }
+        followersNumberElement.innerText = responses.length;
         responses.forEach((response) => {
           console.log("Exists!");
           console.log(followersElement);
@@ -153,12 +156,15 @@ function fetchFollowings() {
     .then(response => response.json())
     .then((responses) => {
       const followingsElement = document.getElementById("followings-details-modal-body");
+      while (followingsElement.firstChild) {
+        followingsElement.removeChild(followingsElement.firstChild);
+      }
+      const followingsNumberElement = document.getElementById("followings-num");
       if (responses === null) {
         followingsElement.appendChild(document.createTextNode("You haven't followed anyone yet."));
+        followingsNumberElement.innerText = '0';
       } else {
-        while (followingsElement.firstChild) {
-          followingsElement.removeChild(followingsElement.firstChild);
-        }
+        followingsNumberElement.innerText = responses.length;
         responses.forEach((response) => {
           console.log("Exists!");
           console.log(followingsElement);

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -127,6 +127,9 @@ function fetchFollowers() {
       if (responses === null) {
         followersElement.appendChild(document.createTextNode("You don't have any followers yet."));
       } else {
+        while (followersElement.firstChild) {
+          followersElement.removeChild(followersElement.firstChild);
+        }
         responses.forEach((response) => {
           console.log("Exists!");
           console.log(followersElement);
@@ -153,6 +156,9 @@ function fetchFollowings() {
       if (responses === null) {
         followingsElement.appendChild(document.createTextNode("You haven't followed anyone yet."));
       } else {
+        while (followingsElement.firstChild) {
+          followingsElement.removeChild(followingsElement.firstChild);
+        }
         responses.forEach((response) => {
           console.log("Exists!");
           console.log(followingsElement);
@@ -164,7 +170,7 @@ function fetchFollowings() {
           userDiv.setAttribute('class','list-group-item list-group-item-action');
           userDiv.setAttribute('onclick', `location.href='/user-page.html?user=${response}'`);
 
-          followersElement.appendChild(userDiv);
+          followingsElement.appendChild(userDiv);
         });
       }
     })

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -127,7 +127,7 @@ function fetchFollowers() {
       while (followersElement.firstChild) {
         followersElement.removeChild(followersElement.firstChild);
       }
-      const followersNumberElement = document.getElementById("followers-num");
+      const followersNumberElement = document.getElementById('followers-num');
       if (responses === null) {
         followersElement.appendChild(document.createTextNode("You don't have any followers yet."));
         followersNumberElement.innerText = '0';
@@ -159,7 +159,7 @@ function fetchFollowings() {
       while (followingsElement.firstChild) {
         followingsElement.removeChild(followingsElement.firstChild);
       }
-      const followingsNumberElement = document.getElementById("followings-num");
+      const followingsNumberElement = document.getElementById('followings-num');
       if (responses === null) {
         followingsElement.appendChild(document.createTextNode("You haven't followed anyone yet."));
         followingsNumberElement.innerText = '0';


### PR DESCRIPTION
Previously, follow and unfollow buttons in `See Around` don't toggle when clicked. Changes in `build-messages.js` is to make that working.

Previously, in `Your Profile`, when `View detail` buttons for followers and followings are clicked for second time or so on, the previous lists are not deleted. I have added that bug in team document. It is now fixed. Changes in 'user-page-loader.js' is to make that working. Also, I added a few line to update related followers or followings numbers when these buttons are clicked.